### PR TITLE
Add: table의 row가 삭제될 때,  삭제되는 row의 컬럼에 종속된 다른 table의 row도 삭제되도록 변경

### DIFF
--- a/db/db_diagram.dbml
+++ b/db/db_diagram.dbml
@@ -12,7 +12,7 @@ table users as u {
 table posts as p {
   id integer [pk, increment]
   users_id integer [ref: > u.id, not null]
-  categories_id integer [ref: > cate.id]
+  categories_id integer [note: 'ref: > cate.id']
   topics_id integer [ref: > t.id, not null]
   title varchar(300) [not null]
   content varchar(1500) [not null]
@@ -43,8 +43,8 @@ table follow {
 
 table comments as cmt {
   id integer [pk, increment]
-  posts_id integer [ref: > p.id]
-  comments_id integer [ref: > cmt.id]
+  posts_id integer [note: 'ref: > p.id']
+  comments_id integer [note: 'ref: > cmt.id']
   users_id integer [ref: > u.id]
   comment_content varchar(1000) [not null]
   created_at datetime [not null, default: `now()`]
@@ -55,11 +55,17 @@ table tags {
   tag_name varchar(150) [not null, unique]
 }
 
-table posts_tags {
+table posts_tags as pt {
   id integer [pk, increment]
-  posts_id int [not null, ref: > p.id]
-  tags_id int [not null, ref: > tags.id]
+  posts_id integer [not null, note: 'ref: > posts.id']
+  tags_id integer [not null, note: 'ref: > tags.id']
   Indexes {
     (posts_id, tags_id) [unique]
   }
 }
+
+ref: p.categories_id > cate.id [delete: cascade]
+ref: pt.posts_id > p.id [delete: cascade]
+ref: pt.tags_id > tags.id [delete: cascade]
+ref: cmt.posts_id > p.id [delete: cascade]
+ref: cmt.comments_id > cmt.id [delete: cascade]

--- a/db/migrations/20230105141021_create_table.sql
+++ b/db/migrations/20230105141021_create_table.sql
@@ -13,7 +13,7 @@ CREATE TABLE `users` (
 CREATE TABLE `posts` (
   `id` integer PRIMARY KEY AUTO_INCREMENT,
   `users_id` integer NOT NULL,
-  `categories_id` integer,
+  `categories_id` integer COMMENT 'ref: > cate.id',
   `topics_id` integer NOT NULL,
   `title` varchar(300) NOT NULL,
   `content` varchar(1500) NOT NULL,
@@ -41,8 +41,8 @@ CREATE TABLE `follow` (
 
 CREATE TABLE `comments` (
   `id` integer PRIMARY KEY AUTO_INCREMENT,
-  `posts_id` integer,
-  `comments_id` integer,
+  `posts_id` integer COMMENT 'ref: > p.id',
+  `comments_id` integer COMMENT 'ref: > cmt.id',
   `users_id` integer,
   `comment_content` varchar(1000) NOT NULL,
   `created_at` datetime NOT NULL DEFAULT (now())
@@ -55,8 +55,8 @@ CREATE TABLE `tags` (
 
 CREATE TABLE `posts_tags` (
   `id` integer PRIMARY KEY AUTO_INCREMENT,
-  `posts_id` int NOT NULL,
-  `tags_id` int NOT NULL
+  `posts_id` integer NOT NULL COMMENT 'ref: > posts.id',
+  `tags_id` integer NOT NULL COMMENT 'ref: > tags.id'
 );
 
 CREATE UNIQUE INDEX `follow_index_0` ON `follow` (`users_id`, `target_users_id`);
@@ -64,8 +64,6 @@ CREATE UNIQUE INDEX `follow_index_0` ON `follow` (`users_id`, `target_users_id`)
 CREATE UNIQUE INDEX `posts_tags_index_1` ON `posts_tags` (`posts_id`, `tags_id`);
 
 ALTER TABLE `posts` ADD FOREIGN KEY (`users_id`) REFERENCES `users` (`id`);
-
-ALTER TABLE `posts` ADD FOREIGN KEY (`categories_id`) REFERENCES `categories` (`id`);
 
 ALTER TABLE `posts` ADD FOREIGN KEY (`topics_id`) REFERENCES `topics` (`id`);
 
@@ -75,15 +73,17 @@ ALTER TABLE `follow` ADD FOREIGN KEY (`users_id`) REFERENCES `users` (`id`);
 
 ALTER TABLE `follow` ADD FOREIGN KEY (`target_users_id`) REFERENCES `users` (`id`);
 
-ALTER TABLE `comments` ADD FOREIGN KEY (`posts_id`) REFERENCES `posts` (`id`);
-
-ALTER TABLE `comments` ADD FOREIGN KEY (`comments_id`) REFERENCES `comments` (`id`);
-
 ALTER TABLE `comments` ADD FOREIGN KEY (`users_id`) REFERENCES `users` (`id`);
 
-ALTER TABLE `posts_tags` ADD FOREIGN KEY (`posts_id`) REFERENCES `posts` (`id`);
+ALTER TABLE `posts` ADD FOREIGN KEY (`categories_id`) REFERENCES `categories` (`id`) ON DELETE CASCADE;
 
-ALTER TABLE `posts_tags` ADD FOREIGN KEY (`tags_id`) REFERENCES `tags` (`id`);
+ALTER TABLE `posts_tags` ADD FOREIGN KEY (`posts_id`) REFERENCES `posts` (`id`) ON DELETE CASCADE;
+
+ALTER TABLE `posts_tags` ADD FOREIGN KEY (`tags_id`) REFERENCES `tags` (`id`) ON DELETE CASCADE;
+
+ALTER TABLE `comments` ADD FOREIGN KEY (`posts_id`) REFERENCES `posts` (`id`) ON DELETE CASCADE;
+
+ALTER TABLE `comments` ADD FOREIGN KEY (`comments_id`) REFERENCES `comments` (`id`) ON DELETE CASCADE;
 
 -- migrate:down
 SET foreign_key_checks = 0;


### PR DESCRIPTION
- 대상 table: comments, posts_tags, posts

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
Add: table의 row가 삭제될 때,  삭제되는 row의 컬럼에 종속된 다른 table의 row도 삭제되도록 변경
- ex) "일기" 카테고리 삭제 시, "일기" 카테고리를 가진 게시글도 같이 삭제하도록 변경
- 게시글 삭제 시, 게시글과 관련된 댓글도 삭제되도록 변경
- 댓글 삭제 시, 대댓글도 같이 삭제되도록 변경
<br />
