### PR TITLE
Fix: 게시글 수정 시, tagName에 아무것도 입력하지 않으면 에러가 발생하는 현상 수정

### DIFF
--- a/src/controllers/post.controller.ts
+++ b/src/controllers/post.controller.ts
@@ -14,7 +14,7 @@ const createPosts = async (req: express.Request, res: express.Response) => {
     thumnail: req.file || null,
     secretType: secretType || 0,
     topicId: topicId,
-    tagNames: tagNames? tagNames.split(',') : [tagNames],
+    tagNames: tagNames?.split(','),
   }
 
   await postSvc.createPosts(input);
@@ -40,7 +40,7 @@ const deletePosts = async (req: express.Request, res: express.Response) => {
 
 const updatePosts = async (req: express.Request, res: express.Response) => {
   const { id: postId } = req.params;
-  const { title, categoryId, content, secretType, topicId, tagNames} = req.body;
+  const { title, categoryId, content, secretType, topicId, tagNames } = req.body;
   const input = {
     postId,
     title,
@@ -50,7 +50,7 @@ const updatePosts = async (req: express.Request, res: express.Response) => {
     thumnail: req.file || null,
     secretType: secretType || 0,
     topicId: topicId,
-    tagNames: tagNames? tagNames.split(',') : [tagNames],
+    tagNames: tagNames?.split(','),
   }
 
   await postSvc.updatePosts(input);


### PR DESCRIPTION

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 버그 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Fix: 게시글 수정 시, tagName에 아무것도 입력하지 않으면 에러가 발생하는 현상 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 원인: tagName이 빈 단어("")일 경우에 대한 처리를 하지 않음
- 해결: tagName이 빈 단어("")일 경우에 tagList를 비우도록 수정

<br />
