### PR TITLE
Fix: 카테고리명이 유저 X 카테고리명으로 고유하도록 설정

### DIFF
--- a/db/db_diagram.dbml
+++ b/db/db_diagram.dbml
@@ -24,7 +24,10 @@ table posts as p {
 table categories as cate {
   id integer [pk, increment]
   users_id integer [ref: > u.id]
-  category_name varchar(150) [not null, unique]
+  category_name varchar(150) [not null]
+  Indexes {
+    (users_id, category_name) [unique]
+  }
 }
 
 table topics as t {

--- a/db/migrations/20230105141021_create_table.sql
+++ b/db/migrations/20230105141021_create_table.sql
@@ -25,7 +25,7 @@ CREATE TABLE `posts` (
 CREATE TABLE `categories` (
   `id` integer PRIMARY KEY AUTO_INCREMENT,
   `users_id` integer,
-  `category_name` varchar(150) UNIQUE NOT NULL
+  `category_name` varchar(150) NOT NULL
 );
 
 CREATE TABLE `topics` (
@@ -59,9 +59,11 @@ CREATE TABLE `posts_tags` (
   `tags_id` integer NOT NULL COMMENT 'ref: > tags.id'
 );
 
-CREATE UNIQUE INDEX `follow_index_0` ON `follow` (`users_id`, `target_users_id`);
+CREATE UNIQUE INDEX `categories_index_0` ON `categories` (`users_id`, `category_name`);
 
-CREATE UNIQUE INDEX `posts_tags_index_1` ON `posts_tags` (`posts_id`, `tags_id`);
+CREATE UNIQUE INDEX `follow_index_1` ON `follow` (`users_id`, `target_users_id`);
+
+CREATE UNIQUE INDEX `posts_tags_index_2` ON `posts_tags` (`posts_id`, `tags_id`);
 
 ALTER TABLE `posts` ADD FOREIGN KEY (`users_id`) REFERENCES `users` (`id`);
 


### PR DESCRIPTION

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 버그 수정


<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 카테고리명이 유저 X 카테고리명으로 고유하도록 설정
- 원인: 유저별로 카테고리명이 고유하여야 하나 유저별로 고려하지 않고 카테고리명 자체로 고유하도록 되어있어 다른 사람이 카테고리명을 선점하면 자신이 원하는 카테고리명을 만들 수 없음.
- 해결: 유저별로 카테고리명이 고유하도록 수정
<br />
