### PR TITLE
Fix: 댓글을 작성한 유저의 프로필 이미지가 함께 보이도록 수정

### DIFF
--- a/src/models/comment.dao.ts
+++ b/src/models/comment.dao.ts
@@ -29,7 +29,9 @@ const getComments = async (postId: string) => {
                   'nickname',
                   users.nickname,
                   'email',
-                  users.email
+                  users.email,
+                  'profileImgUrl',
+                  users.profile_img_url
                 ) AS user
               FROM
                 comments
@@ -41,7 +43,13 @@ const getComments = async (postId: string) => {
         )
         .then((comments) => {
             return [...comments].map((comment) => {
-                return { ...comment, user: JSON.parse(comment.user) };
+                const domain = `${process.env.HOST_URL || "http://localhost"}:${process.env.PORT || 5500}`;
+                let user = JSON.parse(comment.user);
+                let profileImgUrl = user.profileImgUrl ? `${domain}${user.profileImgUrl}` : `${domain}/user/default-img.png`;
+                return {
+                    ...comment,
+                    user: { ...user, profileImgUrl },
+                };
             });
         });
     return comments;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

댓글 작성 시, 유저의 닉네임과 댓글 내용만 보이고 있는 문제점이 있었음.
-> 해결: 댓글을 작성한 유저의 프로필 이미지가 함께 보이도록 comment.dao.ts의 getComments 수정