### PR TITLE
Fix: 게시글 변경이 되지 않는 현상 수정

### DIFF
--- a/src/dtos/posts.dto.ts
+++ b/src/dtos/posts.dto.ts
@@ -157,7 +157,7 @@ export class UpdatePostDto {
   static async factory(req: express.Request) : Promise<UpdatePostDto> {
     const input = {
       ...req.body,
-      postId: req.params.postId,
+      postId: req.params.id,
       userId: req.userInfo.id,
       cateId: req.body.categoryId,
       thumnail: req.body.thumnail === undefined ? req.file : "",

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -3,7 +3,7 @@ const { commentDao, postDao } = dao_set;
 
 // 댓글 생성
 const createComments = async (postId: number, content: string, userId: number) => {
-    const [post] = await postDao.getPosts({ postId });
+    const [post] = await postDao.getPosts({ postId, loginedUserId: userId });
     if (!post) {
         throw { status: 400, message: "존재하지 않는 게시글입니다." };
     }

--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -92,14 +92,14 @@ const updateTagOnPost = async (postId: number, tagNames: string[]) => {
     .map(v =>(v.trim()));
 
   // 새로운 태그 생성 및 포스트와 태그 연결
-  trimedTagNames.forEach(async (tagName) => {
+  for (const tagName of trimedTagNames) {
     let [tag] = await tagDao.getTags(tagName);
     if (!tag) {
       tag = await tagDao.createTags(tagName);
     }
     tag.id = tag.id || tag.insertId;
     await postTagDao.createPostTags(postId, tag.id);
-  })
+  }
 }
 
 export default {


### PR DESCRIPTION
Fix: 게시글 변경이 되지 않는 현상 수정
- 원인: 게시글의 id에 해당하는 변수명은 id 이나 postId 로 잘못 기입함.
- 해결: id로 변수명 변경

Fix: 비밀글에 댓글을 달 수 없는 현상 수정
- 원인: 댓글 추가 시, 게시글이 존재하는 지 확인하나 존재하지 않는다고 표시됨. 이는,  게시글 getPost함수 호출 시, 게시글 접근 권한이 있는 지 확인할 수 있는 인자(loginedUser)를 넣지 않아 게시글을 얻어올 수 없어 발생함.
- 해결: 게시글 getPosts 함수를 호출 시 사용자 인증을 위해  loginedUser에 자신의 유저id를 넣도록 변경

Fix: 데드락 수정
- 원인: postTags 테이블에 여러 쓰레드가 동시에 접근/생성하려 했기 때문
- 해결:  함수가 순차적으로 실행되도록 for 문으로 변경

관련 이슈  정리 URL:
 - https://sororiri.tistory.com/12

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 버그 수정

<br />
